### PR TITLE
supports php highlighting (assuming upstream fix is correct)

### DIFF
--- a/grammars/jekyll-syntax-highlighting.cson
+++ b/grammars/jekyll-syntax-highlighting.cson
@@ -253,7 +253,7 @@
     'contentName': 'source.embedded.php'
     'patterns': [
       {
-        'include': 'source.php'
+        'include': 'text.html.php'
       }
     ]
   }

--- a/spec/jekyll-syntax-highlighting-spec.coffee
+++ b/spec/jekyll-syntax-highlighting-spec.coffee
@@ -24,6 +24,13 @@ describe "loads jekyll-syntax-highlighting grammar", ->
     expect(tokens[0]).toEqual value: "{% highlight ruby %}", scopes: ["text.jekyll", "markup.code.ruby.gfm", "support.gfm"]
     expect(ruleStack[1].contentScopeName).toBe "source.embedded.ruby"
 
+  it "tokenizes an embedded php block", ->
+    {tokens, ruleStack} = grammar.tokenizeLine("{% highlight php %}")
+    expect(tokens[0]).toEqual value: "{% highlight php %}", scopes: ["text.jekyll", "markup.code.php.gfm", "support.gfm"]
+
+    {tokens, ruleStack} = grammar.tokenizeLine("<?php", ruleStack)
+    expect(tokens[0]).toEqual value: "<?php", scopes: ["text.jekyll", "markup.code.php.gfm", "source.embedded.php"]
+
   it "tokenizes the endhighlight", ->
     {tokens, ruleStack} = grammar.tokenizeLine("{% highlight js %}")
     {tokens, ruleStack} = grammar.tokenizeLine("console.log('nothing to see here');", ruleStack)


### PR DESCRIPTION
Assumes this (https://github.com/atom/language-gfm/pull/216) is the right fix--not 100% sure.

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1423258/31922069-ea01b9f0-b840-11e7-9f7f-7999ca23df18.png)  | ![image](https://user-images.githubusercontent.com/1423258/31922071-ecb84aa6-b840-11e7-88ba-0fc36a6e6771.png) |

☝️ It'd be closer. Looks like HTML within a PHP code block isn't getting highlighted quite right 🙄. Probably, related to the layered injections that are happening, but I'm not at all sure what.
